### PR TITLE
fix: consolidate sexual misconduct keywords

### DIFF
--- a/src/utils/incidentLogic.ts
+++ b/src/utils/incidentLogic.ts
@@ -57,8 +57,17 @@ const LOGIC_MAP: IncidentLogicMap = {
     keywords: ['artist off stage', 'main act finished']
   },
   'Sexual Misconduct': {
-    keywords: ['sexual', 'harassment', 'inappropriate touching'],
-    priority: 'high'
+    keywords: [
+      'sexual',
+      'harassment',
+      'inappropriate touching',
+      'rape',
+      'sexual assault',
+      'sexual misconduct',
+      'sexual harassment',
+      'assault'
+    ],
+    priority: 'urgent'
   },
   'Event Timing': {
     keywords: ['timing', 'delayed', 'running late', 'schedule']
@@ -131,10 +140,6 @@ const LOGIC_MAP: IncidentLogicMap = {
     keywords: ['fight', 'altercation', 'brawl'],
     priority: 'high'
   },
-  'Sexual Misconduct': {
-    keywords: ['rape', 'sexual assault', 'sexual misconduct', 'sexual harassment', 'assault'],
-    priority: 'urgent'
-  }
 };
 
 export interface IncidentDetectionResult {


### PR DESCRIPTION
## Summary
- merge duplicate 'Sexual Misconduct' entries in incident logic
- elevate priority to urgent and combine keywords to cover more scenarios

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_689d453dc9408333bbb96ee90a30fbf0