### PR TITLE
feat: add risk weight and crowd analytics helpers

### DIFF
--- a/src/app/api/analytics/crowd-density-predictions/route.ts
+++ b/src/app/api/analytics/crowd-density-predictions/route.ts
@@ -35,7 +35,7 @@ export interface CrowdDensityPredictionsResponse {
     zone: string;
     currentOccupancy: number;
     predictedPeak: number;
-    riskLevel: 'low' | 'medium' | 'high';
+    riskLevel: 'low' | 'medium' | 'high' | 'critical';
     recommendations: string[];
   }[];
   crowdBehavior: {

--- a/src/lib/patternRecognition.ts
+++ b/src/lib/patternRecognition.ts
@@ -550,4 +550,25 @@ export class PatternRecognitionEngine {
       await this.storePatterns(this.patterns);
     }
   }
+
+  async analyzeCrowdFlowPatterns(): Promise<IncidentPattern[]> {
+    // For now, reuse existing incident pattern analysis
+    return this.analyzeIncidentPatterns();
+  }
+
+  async getHistoricalCrowdFlow(): Promise<any[]> {
+    try {
+      const { data, error } = await supabase
+        .from('attendance_records')
+        .select('*')
+        .eq('event_id', this.eventId)
+        .order('timestamp', { ascending: true });
+
+      if (error) throw error;
+      return data || [];
+    } catch (error) {
+      logger.error('Error fetching historical crowd flow', { error, eventId: this.eventId });
+      return [];
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add default risk weight constants and CRUD methods to risk scoring engine
- extend crowd flow prediction with occupancy helpers and zone analysis details
- add stub crowd flow pattern methods in pattern recognition engine
- expand crowd density API types to include critical zone risk levels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Requires ESLint configuration)*
- `npm run build` *(fails: Property 'analyzeWeatherPatterns' does not exist on type 'PatternRecognitionEngine')*

------
https://chatgpt.com/codex/tasks/task_e_68b32d41493883339e06a0cb989e79d8